### PR TITLE
Added api for explicit reset via callback ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,37 @@ ReactDOM.render(
 );
 ```
 
+### Explicitly reset the reCAPTCHA widget
+
+The reCAPTCHA widget can be manually reset by accessing the component instance via a callback ref and calling `.reset()` on the instance.
+
+```javascript
+var Recaptcha = require('react-recaptcha');
+
+// create a variable to store the component instance
+let recaptchaInstance;
+
+// create a reset function
+const resetRecaptcha = () => {
+  recaptchaInstance.reset();  
+};
+
+ReactDOM.render(
+  <div>
+    <Recaptcha
+      ref={e => recaptchaInstance = e}
+      sitekey="xxxxxxxxxxxxxxxxxxxx"
+    />
+    <button
+      onClick={resetRecaptcha}
+    >
+     Reset
+    </button>
+  </div>,
+  document.getElementById('example')
+);
+```
+
 # Contributing
 
 * 1. Fork it

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ export default class Recaptcha extends Component {
   constructor(props) {
     super(props);
     this._renderGrecaptcha = this._renderGrecaptcha.bind(this);
+    this.reset = this.reset.bind(this);
     this.state = {
       ready: isReady(),
     };

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,12 @@ export default class Recaptcha extends Component {
     }
   }
 
+  reset() {
+    if (this.state.ready) {
+      grecaptcha.reset();
+    }
+  }
+
   updateReadyState() {
     if (isReady()) {
       this.setState({

--- a/src/index.js
+++ b/src/index.js
@@ -40,19 +40,19 @@ export default class Recaptcha extends Component {
 
   constructor(props) {
     super(props);
-    this.renderGrecaptcha = this.renderGrecaptcha.bind(this);
+    this._renderGrecaptcha = this._renderGrecaptcha.bind(this);
     this.state = {
       ready: isReady(),
     };
 
     if (!this.state.ready) {
-      readyCheck = setInterval(this.updateReadyState.bind(this), 1000);
+      readyCheck = setInterval(this._updateReadyState.bind(this), 1000);
     }
   }
 
   componentDidMount() {
     if (this.state.ready) {
-      this.renderGrecaptcha();
+      this._renderGrecaptcha();
     }
   }
 
@@ -60,7 +60,7 @@ export default class Recaptcha extends Component {
     const { render, onloadCallback } = this.props;
 
     if (render === 'explicit' && onloadCallback && this.state.ready && !prevState.ready) {
-      this.renderGrecaptcha();
+      this._renderGrecaptcha();
     }
   }
 
@@ -70,7 +70,7 @@ export default class Recaptcha extends Component {
     }
   }
 
-  updateReadyState() {
+  _updateReadyState() {
     if (isReady()) {
       this.setState({
         ready: true,
@@ -80,7 +80,7 @@ export default class Recaptcha extends Component {
     }
   }
 
-  renderGrecaptcha() {
+  _renderGrecaptcha() {
     grecaptcha.render(this.props.elementID, {
       sitekey: this.props.sitekey,
       callback: (this.props.verifyCallback) ? this.props.verifyCallback : undefined,


### PR DESCRIPTION
The component class now has a reset method that can be accessed via a callback ref.

The use case for this feature is the root of [issue 14](https://github.com/appleboy/react-recaptcha/issues/14), [issue 20](https://github.com/appleboy/react-recaptcha/issues/20) and [issue 27](https://github.com/appleboy/react-recaptcha/issues/27).