### PR TITLE
Removed react/jsx-no-bind eslint rule for succinct callback ref syntax

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "console": true
   },
   "rules": {
-    "no-console": 0
+    "no-console": 0,
+    "react/jsx-no-bind": 0
   }
 }


### PR DESCRIPTION
In preparation for adding a reset button to the example using a callback ref.