### PR TITLE
clearInterval added in componentWillUnmount()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,10 @@ export default class Recaptcha extends Component {
     }
   }
 
+  componentWillUnmount() {
+    clearInterval(readyCheck);
+  }
+
   reset() {
     if (this.state.ready) {
       grecaptcha.reset();


### PR DESCRIPTION
There is a problem with Interval `readyCheck` - if component was unmounted before `isReady()` check passed, a warning appears in console:

_Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Recaptcha component._

Solution: clear `readyCheck` in `componentWillUnmount()`.