### PR TITLE
PropTypes update to remove deprecated warning

### DIFF
--- a/__tests__/recaptcha-test.js
+++ b/__tests__/recaptcha-test.js
@@ -1,7 +1,7 @@
 jest.dontMock('../src/index');
 
 import React from 'react';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import Recaptcha from '../src/index';
 
 describe('Recaptcha Test', () => {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-plugin-react": "^3.14.0",
-    "jest": "^14.0.0",
-    "jest-cli": "^14.0.1",
+    "jest": "^20.0.4",
+    "jest-cli": "^20.0.4",
     "pre-commit": "^1.1.2",
-    "react": "^0.14.5",
-    "react-addons-test-utils": "^0.14.5",
-    "react-dom": "^0.14.5",
+    "prop-types": "^15.5.10",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "react-hot-loader": "^1.3.0",
     "react-transform-catch-errors": "^1.0.1",
     "react-transform-hmr": "^1.0.1",
@@ -60,13 +60,11 @@
     "webpack-dev-server": "^1.14.0"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "transform": {
+      ".*": "<rootDir>/node_modules/babel-jest"
+    },
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react"
-    ],
-    "testFileExtensions": [
-      "js",
-      "jsx"
     ],
     "moduleFileExtensions": [
       "js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
Changed PropTypes to come from the npm prop-types package to remove the deprecated warning in the browser.