### PR TITLE
Upgrade PropTypes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,34 +4,24 @@
     "add-module-exports"
   ],
   "env": {
-    // this plugin will be included only in development mode, e.g.
-    // if NODE_ENV (or BABEL_ENV) environment variable is not set
-    // or is equal to "development"
     "development": {
       "plugins": [
-        // must be an array with options object as second item
         ["react-transform", {
-          // must be an array of objects
           "transforms": [{
-            // can be an NPM module name or a local path
             "transform": "react-transform-hmr",
-            // see transform docs for "imports" and "locals" dependencies
             "imports": ["react"],
             "locals": ["module"]
           }, {
-            // you can have many transforms, not just one
             "transform": "react-transform-catch-errors",
             "imports": ["react", "redbox-react"]
           }]
-          // by default we only look for `React.createClass` (and ES6 classes)
-          // but you can tell the plugin to look for different component factories:
-          // factoryMethods: ["React.createClass", "createClass"]
         }]
       ]
     },
+    "test": {},
     "production": {
       "plugins": [
-        "add-module-exports"
+        "transform-react-remove-prop-types"
       ]
     }
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,10 +2,12 @@
   "extends": "airbnb",
   "globals": {
     "grecaptcha": true,
-    "console": true
+    "console": true,
+    "window": true
   },
   "rules": {
     "no-console": 0,
-    "react/jsx-no-bind": 0
+    "react/jsx-no-bind": 0,
+    "react/jsx-filename-extension": 0
   }
 }

--- a/__tests__/recaptcha-test.js
+++ b/__tests__/recaptcha-test.js
@@ -1,13 +1,15 @@
-jest.dontMock('../src/index');
+/* global jest, describe, it, expect */
 
+jest.dontMock('../src/index');
 import React from 'react';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import Recaptcha from '../src/index';
+
 
 describe('Recaptcha Test', () => {
   it('should exists', () => {
     // Render into document
-    let recaptcha = ReactTestUtils.renderIntoDocument(<Recaptcha sitekey="123456789" />);
+    const recaptcha = ReactTestUtils.renderIntoDocument(<Recaptcha sitekey="123456789" />);
     expect(ReactTestUtils.isCompositeComponent(recaptcha)).toBeTruthy();
   });
 });

--- a/example/main.js
+++ b/example/main.js
@@ -1,3 +1,5 @@
+/* global document */
+/* eslint-disable import/no-extraneous-dependencies */
 import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -16,7 +18,7 @@ const verifyCallback = (response) => {
 };
 
 const expiredCallback = () => {
-  console.log(`Recaptcha expired`);
+  console.log('Recaptcha expired');
 };
 
 // define a variable to store the recaptcha instance
@@ -33,7 +35,7 @@ class App extends React.Component {
       <div>
         <h1>Google Recaptcha</h1>
         <Recaptcha
-          ref={e => recaptchaInstance = e}
+          ref={(e) => { recaptchaInstance = e; }}
           sitekey={sitekey}
           size="compact"
           render="explicit"
@@ -41,7 +43,7 @@ class App extends React.Component {
           onloadCallback={callback}
           expiredCallback={expiredCallback}
         />
-        <br/>
+        <br />
         <button
           onClick={resetRecaptcha}
         >

--- a/example/server.js
+++ b/example/server.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 const config = require('./webpack.config');

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,4 +1,5 @@
 import webpack from 'webpack';
+
 const port = process.env.PORT || 3000;
 
 /**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "babel-node example/server.js",
     "compile": "webpack -p --config webpack.production.config.js",
     "lint": "eslint src example",
-    "test": "BABEL_ENV=production jest",
+    "test": "BABEL_ENV=test jest",
     "prepublish": "NODE_ENV=production npm run compile"
   },
   "repository": {
@@ -30,48 +30,49 @@
     "url": "https://github.com/appleboy/react-recaptcha/issues"
   },
   "homepage": "https://github.com/appleboy/react-recaptcha",
+  "peerDependencies": {
+    "react": "^0.14.5 || ^15.0.0",
+    "prop-types": "^15.0.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-core": "^6.3.26",
-    "babel-jest": "^14.0.0",
-    "babel-loader": "^6.2.1",
+    "babel-jest": "^20.0.3",
+    "babel-loader": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.0",
     "babel-plugin-react-transform": "^2.0.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.5",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "babel-runtime": "^6.3.19",
-    "eslint": "^1.10.3",
-    "eslint-config-airbnb": "^5.0.0",
-    "eslint-plugin-react": "^3.14.0",
-    "jest": "^14.0.0",
-    "jest-cli": "^14.0.1",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-jsx-a11y": "^5.0.3",
+    "eslint-plugin-react": "^7.0.1",
+    "jest": "^20.0.4",
+    "jest-cli": "^20.0.4",
     "pre-commit": "^1.1.2",
-    "react": "^0.14.5",
-    "react-addons-test-utils": "^0.14.5",
-    "react-dom": "^0.14.5",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
     "react-hot-loader": "^1.3.0",
     "react-transform-catch-errors": "^1.0.1",
     "react-transform-hmr": "^1.0.1",
-    "redbox-react": "^1.2.0",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "redbox-react": "^1.4.0",
+    "webpack": "^2.6.1",
+    "webpack-dev-server": "^2.4.5"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "transform": {
+      ".*": "<rootDir>/node_modules/babel-jest"
+    },
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react"
-    ],
-    "testFileExtensions": [
-      "js",
-      "jsx"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "jsx"
     ]
-  }
+  },
+  "dependencies": {},
+  "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-recaptcha",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A react.js reCAPTCHA for Google",
   "main": "dist/react-recaptcha.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ export default class Recaptcha extends Component {
     this.reset = this.reset.bind(this);
     this.state = {
       ready: isReady(),
+      widget: null
     };
 
     if (!this.state.ready) {
@@ -70,8 +71,9 @@ export default class Recaptcha extends Component {
   }
 
   reset() {
-    if (this.state.ready) {
-      grecaptcha.reset();
+    const { ready, widget } = this.state;
+    if (ready && widget !== null) {
+      grecaptcha.reset(widget);
     }
   }
 
@@ -86,7 +88,7 @@ export default class Recaptcha extends Component {
   }
 
   _renderGrecaptcha() {
-    grecaptcha.render(this.props.elementID, {
+    this.state.widget = grecaptcha.render(this.props.elementID, {
       sitekey: this.props.sitekey,
       callback: (this.props.verifyCallback) ? this.props.verifyCallback : undefined,
       theme: this.props.theme,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
-  className: PropTypes.string,
+  className: PropTypes.string, // eslint-disable-line
   onloadCallbackName: PropTypes.string,
   elementID: PropTypes.string,
   onloadCallback: PropTypes.func,
@@ -12,12 +13,13 @@ const propTypes = {
   theme: PropTypes.string,
   type: PropTypes.string,
   verifyCallbackName: PropTypes.string,
-  expiredCallbackName: PropTypes.string,
+  expiredCallbackName: PropTypes.string, // eslint-disable-line
   size: PropTypes.string,
   tabindex: PropTypes.string,
 };
 
 const defaultProps = {
+  sitekey: '',
   elementID: 'g-recaptcha',
   onloadCallback: undefined,
   onloadCallbackName: 'onloadCallback',
@@ -40,7 +42,7 @@ export default class Recaptcha extends Component {
 
   constructor(props) {
     super(props);
-    this._renderGrecaptcha = this._renderGrecaptcha.bind(this);
+    this.renderGrecaptcha = this.renderGrecaptcha.bind(this);
     this.reset = this.reset.bind(this);
     this.state = {
       ready: isReady(),
@@ -48,13 +50,13 @@ export default class Recaptcha extends Component {
     };
 
     if (!this.state.ready) {
-      readyCheck = setInterval(this._updateReadyState.bind(this), 1000);
+      readyCheck = setInterval(this.updateReadyState.bind(this), 1000);
     }
   }
 
   componentDidMount() {
     if (this.state.ready) {
-      this._renderGrecaptcha();
+      this.renderGrecaptcha();
     }
   }
 
@@ -62,7 +64,7 @@ export default class Recaptcha extends Component {
     const { render, onloadCallback } = this.props;
 
     if (render === 'explicit' && onloadCallback && this.state.ready && !prevState.ready) {
-      this._renderGrecaptcha();
+      this.renderGrecaptcha();
     }
   }
 
@@ -77,7 +79,7 @@ export default class Recaptcha extends Component {
     }
   }
 
-  _updateReadyState() {
+  updateReadyState() {
     if (isReady()) {
       this.setState({
         ready: true,
@@ -87,7 +89,7 @@ export default class Recaptcha extends Component {
     }
   }
 
-  _renderGrecaptcha() {
+  renderGrecaptcha() {
     this.state.widget = grecaptcha.render(this.props.elementID, {
       sitekey: this.props.sitekey,
       callback: (this.props.verifyCallback) ? this.props.verifyCallback : undefined,
@@ -104,21 +106,23 @@ export default class Recaptcha extends Component {
   render() {
     if (this.props.render === 'explicit' && this.props.onloadCallback) {
       return (
-        <div id={this.props.elementID}
+        <div
+          id={this.props.elementID}
           data-onloadcallbackname={this.props.onloadCallbackName}
           data-verifycallbackname={this.props.verifyCallbackName}
-        ></div>
+        />
       );
     }
 
     return (
-      <div className="g-recaptcha"
+      <div
+        className="g-recaptcha"
         data-sitekey={this.props.sitekey}
         data-theme={this.props.theme}
         data-type={this.props.type}
         data-size={this.props.size}
         data-tabindex={this.props.tabindex}
-      ></div>
+      />
     );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default class Recaptcha extends Component {
     this.reset = this.reset.bind(this);
     this.state = {
       ready: isReady(),
-      widget: null
+      widget: null,
     };
 
     if (!this.state.ready) {

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -31,14 +31,16 @@ module.exports = {
   ],
 
   module: {
-    loaders: [{
+    rules: [{
       test: /\.jsx?$/,
       exclude: /node_modules/,
-      loader: 'babel'
+      use: [ {
+        loader: 'babel-loader'
+      } ]
     }]
   },
 
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['.js', '.jsx']
   }
 };


### PR DESCRIPTION
This PR updates the package with the primary intention of removing the deprecated propTypes warning.

Hence, the main work is to add the prop-types package and then to pull from those. Since propTypes are stripped in production, the tests weren't going through, and so upgrading Jest (and the Jest configuration) fixed the tests (and running in `BABEL_ENV=test` instead of `BABEL_ENV=production`.

I moved `react` and `prop-types` to be peerDependencies because the linter was unhappy with those there. Please review that these will work as peer dependencies.

I also upgraded Webpack and the Eslint packages (and did the new linting, which is the majority of the changes). I turned off the `react/jsx-filename-extension` rule in order not to rename files.

Also, to avoid another warning, I added the `license` key to the `package.json` file, which was the license that matched the one in the `LICENSE` file in the repo.