### PR TITLE
fix this.props.onloadCallback is not a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,9 @@ export default class Recaptcha extends Component {
       'expired-callback': (this.props.expiredCallback) ? this.props.expiredCallback : undefined,
     });
 
-    this.props.onloadCallback();
+    if (this.props.onloadCallback) {
+      this.props.onloadCallback();
+    }
   }
 
   render() {
@@ -111,7 +113,7 @@ export default class Recaptcha extends Component {
         <div id={this.props.elementID}
           data-onloadcallbackname={this.props.onloadCallbackName}
           data-verifycallbackname={this.props.verifyCallbackName}
-        ></div>
+        />
       );
     }
 
@@ -123,7 +125,7 @@ export default class Recaptcha extends Component {
         data-type={this.props.type}
         data-size={this.props.size}
         data-tabindex={this.props.tabindex}
-      ></div>
+      />
     );
   }
 }


### PR DESCRIPTION
This PR fix the following console error in production
````
Uncaught TypeError: this.props.onloadCallback is not a function
    at t.value (react-recaptcha.js:1)
    at t.value (react-recaptcha.js:1)
    at ReactCompositeComponent.js:264
    at measureLifeCyclePerf (ReactCompositeComponent.js:75)
    at ReactCompositeComponent.js:263
    at CallbackQueue.notifyAll (CallbackQueue.js:76)
    at ReactReconcileTransaction.close (ReactReconcileTransaction.js:80)
    at ReactReconcileTransaction.closeAll (Transaction.js:209)
    at ReactReconcileTransaction.perform (Transaction.js:156)
    at batchedMountComponentIntoNode (ReactMount.js:126)
````
With this configuration:
````jsx
 <Recaptcha
  verifyCallback={response => onChange(response)}
  sitekey="123456"
/>
````