### PR TITLE
Added .babelrc ignore to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+.babelrc


### PR DESCRIPTION
Out of the box webpack with babel loader is giving us the error below. By removing the `.babelrc` file from the npm-installed package our error was resolved :)

Our project does not require `babel-plugin-add-module-exports`. If babel transforms are required on the build content please consider making those babel plugins dependencies (as opposed to devDependencies), or moving the `.babelrc` file into the `src` directory.

```
ERROR in ./~/react-recaptcha/dist/react-recaptcha.js
Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in "/home/x/node_modules/react-recaptcha/.babelrc" at 0, attempted to resolve relative to "/home/x/node_modules/react-recaptcha"
    at /home/x/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
    at Array.map (native)
    at Function.normalisePlugins (/home/x/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
    at OptionManager.mergeOptions (/home/x/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
    at OptionManager.init (/home/x/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/home/x/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/home/x/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/home/x/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/home/x/node_modules/babel-loader/lib/index.js:46:20)
    at Object.module.exports (/home/x/node_modules/babel-loader/lib/index.js:163:20)
 @ ./app/components/Captcha/index.js 17:22-48
 @ ./app/containers/Captcha.js
 @ ./app/components/Review/index.js
 @ ./app/containers/Review.js
 @ ./app/index.js
 @ ./index.js
 @ multi babel-polyfill ./index.js
```

Thank you sir!