### PR TITLE
fix: add multiple files/folders to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,11 @@
-src
+__tests__
 .babelrc
+.editorconfig
+.eslintrc
+.npmignore
+.travis.yml
+.yarn-cache
+example
+src
+webpack.production.config.js
+yarn.lock


### PR DESCRIPTION
Just a small change to help out Windows CI servers which are struggling with the long filenames inside the `.yarn-cache` folder. Thought I'd just add a few more in there too.