### PR TITLE
add defaultProps for onloadCallback to be function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const propTypes = {
 
 const defaultProps = {
   elementID: 'g-recaptcha',
-  onloadCallback: undefined,
+  onloadCallback: () => null,
   onloadCallbackName: 'onloadCallback',
   verifyCallback: undefined,
   verifyCallbackName: 'verifyCallback',


### PR DESCRIPTION
when user doesn't give `onloadCallback` prop, it doesn't work silently. For example #231
`onloadCallback` prop is not needed for user to provide function for it so I think we should set defaultProps for `onloadCallback` to be empty function. 