### PR TITLE
Allow auto detection of the language.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const defaultProps = {
   type: 'image',
   size: 'normal',
   tabindex: '0',
-  hl: 'en',
+  hl: undefined,
   badge: 'bottomright',
 };
 


### PR DESCRIPTION
Hi @appleboy, setting in the `defaultProps` the `hl` prop to `en`, forces the language to english when the prop is not set. This doesn't allow reCaptcha to auto-detect the language and force non-english people to set a different language instead of leave it undefined.